### PR TITLE
fix raspicat.repos

### DIFF
--- a/raspicat.repos
+++ b/raspicat.repos
@@ -17,7 +17,7 @@ repositories:
     version: ros2
   raspimouse2:
     type: git
-    url: git@github.com:CIT-Autonomous-Robot-Labraspimouse2.git
+    url: git@github.com:CIT-Autonomous-Robot-Lab/raspimouse2.git
     version: master
   raspicat_speak2:
     type: git


### PR DESCRIPTION
20行目の

url: git@github.com:CIT-Autonomous-Robot-Labraspimouse2.git

 CIT-Autonomous-Robot-Labとraspimouse2.git の間にあるはずの / が抜けていました.

修正よろしくお願いします.